### PR TITLE
Handle python versions in build script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,5 @@ language: c
 sudo: required
 services:
   - docker
-env:
-  global:
-    - CONDA_NPY=18
-  matrix:
-    - CONDA_PY=34
-    - CONDA_PY=27
 install: scripts/travis-setup.sh
 script: scripts/travis-run.sh

--- a/scripts/build-packages.py
+++ b/scripts/build-packages.py
@@ -9,10 +9,17 @@ import sys
 import nose
 
 
+PYTHON_VERSIONS = ["27", "34"]
+
+
 def build_recipe(recipe):
     try:
-        sp.check_output(["conda", "build", "--no-anaconda-upload",
-                         "--skip-existing", recipe], stderr=sp.STDOUT)
+        os.environ["CONDA_NPY"] = "18"
+        for py in PYTHON_VERSIONS:
+            os.environ["CONDA_PY"] = py
+            sp.check_output(["conda", "build", "--no-anaconda-upload",
+                             "--skip-existing", recipe],
+                            stderr=sp.STDOUT)
     except sp.CalledProcessError as e:
         print(e.output)
         assert False
@@ -23,7 +30,8 @@ def test_recipes():
         recipes = [os.path.join(args.repository, "recipes", package)
                    for package in args.packages]
     else:
-        recipes = list(glob.glob(os.path.join(args.repository, "recipes", "*")))
+        recipes = list(glob.glob(os.path.join(args.repository, "recipes",
+                                              "*")))
 
     for recipe in recipes:
         yield build_recipe, recipe
@@ -31,9 +39,16 @@ def test_recipes():
     if os.environ.get("TRAVIS_BRANCH") == "master" and os.environ.get(
         "TRAVIS_PULL_REQUEST") == "false":
         for recipe in recipes:
-            package = sp.check_output(["conda", "build", "--output", recipe]).strip()
-            if os.path.exists(package):
-                sp.check_call(["anaconda", "-t", os.environ.get("ANACONDA_TOKEN"), "upload", package])
+            packages = set()
+            os.environ["CONDA_NPY"] = "18"
+            for py in PYTHON_VERSIONS:
+                os.environ["CONDA_PY"] = py
+                packages.add(sp.check_output(["conda", "build", "--output",
+                                              recipe]).strip())
+            for package in packages:
+                if os.path.exists(package):
+                    sp.check_call(["anaconda", "-t", os.environ.get(
+                        "ANACONDA_TOKEN"), "upload", package])
 
 
 if __name__ == "__main__":

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -4,7 +4,7 @@ set -e
 if [[ $TRAVIS_OS_NAME = "linux" ]]
 then
     # run CentOS5 based docker container
-    docker run -e TRAVIS_BRANCH -e TRAVIS_PULL_REQUEST -e ANACONDA_TOKEN -e CONDA_PY -e CONDA_NPY -v `pwd`:/bioconda-recipes bioconda/bioconda-builder
+    docker run -e TRAVIS_BRANCH -e TRAVIS_PULL_REQUEST -e ANACONDA_TOKEN -v `pwd`:/bioconda-recipes bioconda/bioconda-builder
 else
     export PATH=/tmp/anaconda/bin:$PATH
     # build packages


### PR DESCRIPTION
This will avoid redundant builds as they are happening now.