### PR TITLE
Add rsem

### DIFF
--- a/recipes/rsem/build.sh
+++ b/recipes/rsem/build.sh
@@ -1,0 +1,32 @@
+#! /bin/bash
+pushd $SRC_DIR
+
+mkdir -p $PREFIX/bin
+
+binaries="\
+rsem-build-read-index \
+rsem-synthesis-reference-transcripts \
+rsem-tbam2gbam \
+rsem-parse-alignments \
+rsem-simulate-reads \
+rsem-calculate-credibility-intervals \
+rsem-scan-for-paired-end-reads \
+rsem-sam-validator \
+rsem-bam2wig \
+rsem-run-em \
+rsem-get-unique \
+rsem-extract-reference-transcripts \
+rsem-bam2readdepth \
+rsem-preref \
+rsem-run-gibbs \
+rsem_perl_utils.pm \
+WHAT_IS_NEW \
+EBSeq/rsem-for-ebseq-calculate-clustering-info \
+EBSeq/rsem-for-ebseq-find-DE \
+EBSeq/rsem-for-ebseq-generate-ngvector-from-clustering-info \
+"
+
+make
+make ebseq
+
+for i in $binaries; do cp $i $PREFIX/bin && chmod +x $PREFIX/bin/$(basename $i); done

--- a/recipes/rsem/build.sh
+++ b/recipes/rsem/build.sh
@@ -1,8 +1,6 @@
 #! /bin/bash
 pushd $SRC_DIR
 
-mkdir -p $PREFIX/bin
-
 binaries="\
 rsem-build-read-index \
 rsem-synthesis-reference-transcripts \
@@ -20,13 +18,25 @@ rsem-bam2readdepth \
 rsem-preref \
 rsem-run-gibbs \
 rsem_perl_utils.pm \
-WHAT_IS_NEW \
 EBSeq/rsem-for-ebseq-calculate-clustering-info \
 EBSeq/rsem-for-ebseq-find-DE \
 EBSeq/rsem-for-ebseq-generate-ngvector-from-clustering-info \
 "
+WHAT_IS_NEW="WHAT_IS_NEW"
+
+INSTALLDIR=$PREFIX/lib/rsem
+BINDIR=$PREFIX/bin
+mkdir -p $BINDIR
+mkdir -p $INSTALLDIR
 
 make
 make ebseq
 
-for i in $binaries; do cp $i $PREFIX/bin && chmod +x $PREFIX/bin/$(basename $i); done
+for i in $binaries; do cp $i $INSTALLDIR && chmod +x $INSTALLDIR/$(basename $i); done
+cp $WHAT_IS_NEW $INSTALLDIR;
+for i in $binaries; do
+    echo "#! /bin/bash" > $BINDIR/$(basename $i);
+    echo 'DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )' >>  $BINDIR/$(basename $i);
+    echo '$DIR/../lib/rsem/'$(basename $i) >> $BINDIR/$(basename $i);
+    chmod +x $BINDIR/$(basename $i);
+done

--- a/recipes/rsem/meta.yaml
+++ b/recipes/rsem/meta.yaml
@@ -5,6 +5,15 @@ about:
 package:
   name: rsem
   version: 1.2.22
+build:
+  rpaths:
+    - lib/R/lib/
+    - lib/
+requirements:
+  build:
+    - r >=3.1.0
+  run:
+    - r >=3.1.0
 test:
   commands:
     - rsem-prepare-reference 2>&1 | grep rsem-prepare-reference > /dev/null

--- a/recipes/rsem/meta.yaml
+++ b/recipes/rsem/meta.yaml
@@ -1,0 +1,15 @@
+about:
+  home: http://deweylab.biostat.wisc.edu/rsem/
+  license: GPLv3
+  summary: RSEM (RNA-Seq by Expectation-Maximization)
+package:
+  name: rsem
+  version: 1.2.22
+test:
+  commands:
+    - rsem-prepare-reference 2>&1 | grep rsem-prepare-reference > /dev/null
+    - rsem-for-ebseq-find-DE 2>&1 | grep Usage > /dev/null
+source:
+  fn: v1.2.22.tar.gz
+  url: https://github.com/deweylab/RSEM/archive/v1.2.22.tar.gz
+  md5: 7a8373711ca0da79d9e4c9b314955cb3


### PR DESCRIPTION
From install instructions:

"To install, simply put the rsem directory in your environment's PATH variable.

If you prefer to put all RSEM executables to a bin directory, please
also remember to put 'rsem_perl_utils.pm' and 'WHAT_IS_NEW' to the
same bin directory. 'rsem_perl_utils.pm' is required for most RSEM's
perl scripts and 'WHAT_IS_NEW' contains the RSEM version
information."

I currently put the binaries in $PREFIX/bin, even if WHAT_IS_NEW feels
like a generic name that could be overwritten and thus break rsem.
Should packages like this instead live in e.g. /envs/share/rsem? The end
user would then need to setup PATH.