### PR TITLE
pysam: latest GitHub development (0.8.4pre)

### DIFF
--- a/recipes/pysam/meta.yaml
+++ b/recipes/pysam/meta.yaml
@@ -1,14 +1,16 @@
 package:
   name: pysam
-  version: 0.8.3
+  version: 0.8.4pre0
 
 source:
-  fn: pysam-0.8.3.tar.gz
-  url: https://pypi.python.org/packages/source/p/pysam/pysam-0.8.3.tar.gz
-  md5: b1ae2a8ec3c6d20be30b2bc1aa995bbf
+  #fn: pysam-0.8.3.tar.gz
+  #url: https://pypi.python.org/packages/source/p/pysam/pysam-0.8.3.tar.gz
+  #md5: b1ae2a8ec3c6d20be30b2bc1aa995bbf
+  fn: pysam-067d1ad.tar.gz
+  url: https://github.com/pysam-developers/pysam/archive/067d1ad.tar.gz
 
 build:
-  number: 2
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
The latest development pysam collected useful fixes for 0.8.3 but
hasn't gotten a release yet.