### PR TITLE
Bioconductor scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ standard build. To build this yourself, you can do:
     docker login
     cd scripts && docker build -t bicoonda/bioconda-builder .
 
-###Building Bioconductor packages
+###Creating Bioconductor recipes
 A helper script is provided for generating a skeleton recipe for Bioconductor
 packages. The `scripts/bioconductor-scraper.py` script accepts the name of a Bioconductor
 package (e.g., "Biobase"). This script:
@@ -118,3 +118,6 @@ recipes/bioconductor-biobase/meta.yaml
 recipes/bioconductor-biobase/build.sh
 
 ```
+
+After the recipe has been created, you can follow the build test instructions
+above.

--- a/README.md
+++ b/README.md
@@ -91,3 +91,30 @@ standard build. To build this yourself, you can do:
 
     docker login
     cd scripts && docker build -t bicoonda/bioconda-builder .
+
+###Building Bioconductor packages
+A helper script is provided for generating a skeleton recipe for Bioconductor
+packages. The `scripts/bioconductor-scraper.py` script accepts the name of a Bioconductor
+package (e.g., "Biobase"). This script:
+
+- parses the Bioconductor web page for the tarball
+- downloads the tarball to a temp file and extracts the `DESCRIPTION` file
+- parses the DESCRIPTION file to identify dependencies
+- converts dependencies to package names more friendly to `conda`,
+  specifically prefixing `bioconductor-` or `r-` as needed and using lowercase
+  package names
+- writes a `meta.yaml` and `build.sh` file to `recipes/<new package name>`.
+
+That is, 
+
+```bash
+ scripts/bioconductor-scraper.py Biobase
+```
+
+results in the files:
+
+```
+recipes/bioconductor-biobase/meta.yaml
+recipes/bioconductor-biobase/build.sh
+
+```

--- a/recipes/pyaml/bld.bat
+++ b/recipes/pyaml/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/recipes/pyaml/build.sh
+++ b/recipes/pyaml/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/pyaml/meta.yaml
+++ b/recipes/pyaml/meta.yaml
@@ -1,0 +1,64 @@
+package:
+  name: pyaml
+  version: "15.8.2"
+
+source:
+  fn: pyaml-15.8.2.tar.gz
+  url: https://pypi.python.org/packages/source/p/pyaml/pyaml-15.8.2.tar.gz
+  md5: e3a39e02dffaf5f6efa8ccdd22745739
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - pyaml = pyaml:main
+    #
+    # Would create an entry point called pyaml that calls pyaml.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pyyaml
+
+  run:
+    - python
+    - pyyaml
+
+test:
+  # Python imports
+  imports:
+    - pyaml
+    - pyaml.tests
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/mk-fg/pretty-yaml
+  license: WTFPL
+  summary: 'PyYAML-based module to produce pretty and readable YAML-serialized data'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/scripts/bioconductor-scraper.py
+++ b/scripts/bioconductor-scraper.py
@@ -1,44 +1,27 @@
 #!/usr/bin/env python
 
+import tempfile
+import configparser
 from textwrap import dedent
-import yaml
+import tarfile
+import pyaml
 import hashlib
 import os
 import re
 import bs4
+import urllib
 from urllib import request
 from urllib import parse
 from collections import OrderedDict
 
-def ordereddict_constructor(loader, node):
-    try:
-        omap = loader.construct_yaml_omap(node)
-        return OrderedDict(*omap)
-    except yaml.constructor.ConstructorError:
-        return loader.construct_yaml_seq(node)
-
-def represent_ordereddict(dumper, data):
-    # From https://bitbucket.org/xi/pyyaml/issues/13/loading-and-then-dumping-an-omap-is-broken
-    values = []
-    node = yaml.SequenceNode(u'tag:yaml.org,2002:seq', values, flow_style=False)
-    if dumper.alias_key is not None:
-        dumper.represented_objects[dumper.alias_key] = node
-    for key, value in data.items():
-        key_item = dumper.represent_data(key)
-        value_item = dumper.represent_data(value)
-        node_item = yaml.MappingNode(u'tag:yaml.org,2002:map', [(key_item, value_item)],
-                                     flow_style=False)
-        values.append(node_item)
-    return node
-
-yaml.add_constructor(u'tag:yaml.org,2002:seq', ordereddict_constructor)
-yaml.add_representer(OrderedDict, represent_ordereddict)
+base_url = 'http://bioconductor.org/packages/release/bioc/html'
 
 
 class BioCProjectPage(object):
-    def __init__(self, package, base_url='http://bioconductor.org/packages/release/bioc/html'):
+    def __init__(self, package):
         """
-        Represents a single Bioconductor package page and provides access to scraped data.
+        Represents a single Bioconductor package page and provides access to
+        scraped data.
 
         >>> x = BioCProjectPage('DESeq2')
         >>> x.tarball
@@ -54,65 +37,120 @@ class BioCProjectPage(object):
         self.details_table = self.soup.find_all(attrs={'class': 'details'})[0]
         self._md5 = None
         self.sanitized_package = 'bioconductor-' + package.lower()
+        self._cached_tarball = None
 
     @property
-    def tarball(self):
+    def tarball_url(self):
         """
-        Return the url to the tarball indicated in the "Package Source" section.
+        Return the url to the tarball indicated in the "Package Source"
+        section of the project's page.
         """
         r = re.compile('{0}.*\.tar.gz'.format(self.package))
+
         def f(href):
             return href and r.search(href)
+
         results = self.soup.find_all(href=f)
-        assert len(results) == 1, "Found {0} tags with '.tar.gz' in href".format(len(results))
+        assert len(results) == 1, (
+            "Found {0} tags with '.tar.gz' in href".format(len(results)))
         s = list(results[0].stripped_strings)
         assert len(s) == 1
         return os.path.join(parse.urljoin(self.url, '../src/contrib'), s[0])
 
     @property
-    def tarball_filename(self):
-        return os.path.basename(self.tarball)
+    def tarball_basename(self):
+        return os.path.basename(self.tarball_url)
+
+    @property
+    def cached_tarball(self):
+        if self._cached_tarball:
+            return self._cached_tarball
+        fn = tempfile.NamedTemporaryFile(delete=False).name
+        with open(fn, 'wb') as fout:
+            fout.write(request.urlopen(self.tarball_url).read())
+        self._cached_tarball = fn
+        return fn
+
+    @property
+    def description(self):
+        t = tarfile.open(self.cached_tarball)
+        d = t.extractfile(os.path.join(self.package, 'DESCRIPTION')).read()
+        self._contents = d
+        c = configparser.ConfigParser()
+        c.read_string('[top]\n' + d.decode('UTF-8'))
+        e = c['top']
+        for k in e.keys():
+            e[k] = e[k].replace('\n', ' ')
+        return dict(e)
 
     @property
     def version(self):
-        return str(self.details_table.findChild(text='Version').findNext().string)
+        return str(
+            self.details_table.findChild(text='Version').findNext().string)
 
     @property
     def license(self):
-        return str(self.details_table.findChild(text='License').findNext().string)
+        return self.description['license']
 
     @property
     def imports(self):
-        return self.details_table.findChild(text='Imports').findNext().findChildren()
-
-
-    @property
-    def dependencies(self):
-        def _versioned_dependencies(children):
-            results = []
-            for c in children:
-                if c.name == 'a':
-                    pkg = c.string
-                else:
-                    continue
-                if c.next_sibling and c.next_sibling.name is None:
-                    version = c.next_sibling.string.replace(' ', '').replace(',', '')
-                    if version:
-                        version = version.replace('(', ' ').replace(')', '')
-                else:
-                    version = ""
-                if c.get('class') == ['cran_package']:
-                    prefix = 'r-'
-                else:
-                    prefix = 'bioconductor-'
-                results.append(prefix + pkg.lower() + version + ' # ' + pkg)
-            return results
-        return list(set(_versioned_dependencies(self.imports) + _versioned_dependencies(self.depends)))
-
+        try:
+            return self.description['imports'].split(', ')
+        except KeyError:
+            return []
 
     @property
     def depends(self):
-        return self.details_table.findChild(text='Depends').findNext()
+        try:
+            return self.description['depends'].split(', ')
+        except KeyError:
+            return []
+
+    def _parse_dependencies(self, items):
+        results = []
+        for item in items:
+            toks = item.split(' (')
+            if len(toks) == 1:
+                results.append((toks[0], ""))
+            elif len(toks) == 2:
+                assert ')' in toks[1]
+                toks[1] = toks[1].replace(')', '').replace(' ', '')
+                results.append(tuple(toks))
+            else:
+                raise ValueError("Found {0} toks: {1}".format(len(toks), toks))
+        return results
+
+    @property
+    def dependencies(self):
+        results = []
+        specific_r_version = False
+        for name, version in list(
+            set(
+                self._parse_dependencies(self.imports) +
+                self._parse_dependencies(self.depends)
+            )
+        ):
+            # Try finding the dependency on the bioconductor site; if it can't
+            # be found then we assume it's in CRAN.
+            try:
+                BioCProjectPage(name)
+                prefix = 'bioconductor-'
+            except urllib.error.HTTPError:
+                prefix = 'r-'
+            if name in ['methods', 'utils']:
+                continue
+            # add padding
+            if version:
+                version = " " + version
+            if name.lower() == 'r':
+                specific_r_version = True
+                results.append(name.lower() + version)
+            else:
+                results.append(prefix + name.lower() + version)
+
+        if not specific_r_version:
+            results.append('r')
+        return results
 
     @property
     def cleaned_package(self):
@@ -121,7 +159,8 @@ class BioCProjectPage(object):
     @property
     def md5(self):
         if self._md5 is None:
-            self._md5 = hashlib.md5(request.urlopen(self.tarball).read()).hexdigest()
+            self._md5 = hashlib.md5(
+                open(self.cached_tarball, 'rb').read()).hexdigest()
         return self._md5
 
     @property
@@ -139,8 +178,8 @@ class BioCProjectPage(object):
             ),
             (
                 'source', OrderedDict((
-                    ('fn', self.tarball_filename),
-                    ('url', self.tarball),
+                    ('fn', self.tarball_basename),
+                    ('url', self.tarball_url),
                     ('md5', self.md5),
                 )),
             ),
@@ -152,25 +191,27 @@ class BioCProjectPage(object):
             ),
             (
                 'requirements', OrderedDict((
-                    ('build', ['r'] + sorted(self.dependencies)),
-                    ('run', ['r'] + sorted(self.dependencies)),
+                    ('build', sorted(self.dependencies)),
+                    ('run', sorted(self.dependencies)),
                 )),
             ),
             (
                 'test', OrderedDict((
-                    ('commands', """$R -e "library('{package}')""".format(package=self.package)),
+                    ('commands',
+                     ['''$R -e "library('{package}')"'''.format(
+                         package=self.package)]),
                 )),
             ),
             (
                 'about', OrderedDict((
                     ('home', self.url),
                     ('license', self.license),
-                    ('summary', self.summary),
+                    ('summary', self.description['description']),
                 )),
             ),
         ))
-        return yaml.dump(d, default_flow_style=False)
 
+        return pyaml.dumps(d).decode('utf-8')
 
 
 def write_recipe(package, recipe_dir, force=False):
@@ -191,17 +232,19 @@ def write_recipe(package, recipe_dir, force=False):
             """
             #!/bin/bash
 
-            # R refuses to build packages that mark themselves as Priority: Recommended
-            # mv DESCRIPTION DESCRIPTION.old
-            # grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+            # R refuses to build packages that mark themselves as
+            # "Priority: Recommended"
+            mv DESCRIPTION DESCRIPTION.old
+            grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
             #
-            # $R CMD INSTALL --build .
+            $R CMD INSTALL --build .
             #
             # # Add more build steps here, if they are necessary.
             #
-            # # See
-            # # http://docs.continuum.io/conda/build.html
-            # # for a list of environment variables that are set during the build process.
+            # See
+            # http://docs.continuum.io/conda/build.html
+            # for a list of environment variables that are set during the build
+            # process.
             # """
             )
         )
@@ -213,6 +256,7 @@ if __name__ == "__main__":
     ap.add_argument('package', help='Bioconductor package name')
     ap.add_argument('--recipe-dir', default='recipes',
                     help='Recipe will be created in <recipe-dir>/<package>')
-    ap.add_argument('--force', action='store_true', help='Overwrite the contents of an existing recipe')
+    ap.add_argument('--force', action='store_true',
+                    help='Overwrite the contents of an existing recipe')
     args = ap.parse_args()
     write_recipe(args.package, args.recipe_dir, args.force)

--- a/scripts/bioconductor-scraper.py
+++ b/scripts/bioconductor-scraper.py
@@ -22,22 +22,24 @@ class BioCProjectPage(object):
         """
         Represents a single Bioconductor package page and provides access to
         scraped data.
-
         >>> x = BioCProjectPage('DESeq2')
-        >>> x.tarball
+        >>> x.tarball_url
         'http://bioconductor.org/packages/release/bioc/src/contrib/DESeq2_1.8.2.tar.gz'
         """
         self.base_url = base_url
         self.package = package
+        self._md5 = None
+        self._cached_tarball = None
         self.url = os.path.join(base_url, package + '.html')
         self.soup = bs4.BeautifulSoup(
             request.urlopen(self.url),
             'html.parser')
 
+        # The table at the bottom of the page has the info we want. An earlier
+        # draft of this script parsed the dependencies from the details table.
+        # That's still an option if we need a double-check on the DESCRIPTION
+        # fields.
         self.details_table = self.soup.find_all(attrs={'class': 'details'})[0]
-        self._md5 = None
-        self.sanitized_package = 'bioconductor-' + package.lower()
-        self._cached_tarball = None
 
     @property
     def tarball_url(self):
@@ -55,6 +57,10 @@ class BioCProjectPage(object):
             "Found {0} tags with '.tar.gz' in href".format(len(results)))
         s = list(results[0].stripped_strings)
         assert len(s) == 1
+
+        # build the actual URL based on the identified package name and the
+        # relative URL from the source. Here we're just hard-coding
+        # '../src/contrib' based on the structure of the bioconductor site.
         return os.path.join(parse.urljoin(self.url, '../src/contrib'), s[0])
 
     @property
@@ -63,6 +69,13 @@ class BioCProjectPage(object):
 
     @property
     def cached_tarball(self):
+        """
+        Downloads the tarball to a temporary file if one hasn't already been
+        downloaded.
+
+        This is because we need the whole tarball to get the DESCRIPTION file
+        and to generate an md5 hash, so we might as well save it somewhere.
+        """
         if self._cached_tarball:
             return self._cached_tarball
         fn = tempfile.NamedTemporaryFile(delete=False).name
@@ -73,20 +86,29 @@ class BioCProjectPage(object):
 
     @property
     def description(self):
+        """
+        Extract the DESCRIPTION file from the tarball and parse it.
+        """
         t = tarfile.open(self.cached_tarball)
         d = t.extractfile(os.path.join(self.package, 'DESCRIPTION')).read()
         self._contents = d
         c = configparser.ConfigParser()
+
+        # On-spec config files need a "section", but the DESCRIPTION file
+        # doesn't have one. So we just add a fake section, and let the
+        # configparser take care of the details of parsing.
         c.read_string('[top]\n' + d.decode('UTF-8'))
         e = c['top']
+
+        # Glue together newlines
         for k in e.keys():
             e[k] = e[k].replace('\n', ' ')
+
         return dict(e)
 
     @property
     def version(self):
-        return str(
-            self.details_table.findChild(text='Version').findNext().string)
+        return self.description['version']
 
     @property
     def license(self):
@@ -107,6 +129,21 @@ class BioCProjectPage(object):
             return []
 
     def _parse_dependencies(self, items):
+        """
+        The goal is to go from
+
+        ['package1', 'package2', 'package3 (>= 0.1)', 'package4']
+
+        to::
+
+            [
+                ('package1', ""),
+                ('package2', ""),
+                ('package3', " >=0.1"),
+                ('package1', ""),
+            ]
+
+        """
         results = []
         for item in items:
             toks = item.split(' (')
@@ -123,7 +160,11 @@ class BioCProjectPage(object):
     @property
     def dependencies(self):
         results = []
+
+        # Some packages specify a minimum R version, which we'll need to keep
+        # track of
         specific_r_version = False
+
         for name, version in list(
             set(
                 self._parse_dependencies(self.imports) +
@@ -137,42 +178,56 @@ class BioCProjectPage(object):
                 prefix = 'bioconductor-'
             except urllib.error.HTTPError:
                 prefix = 'r-'
+
+            # These seem to be built-in R packages so we don't need to
+            # explicitly depend on them. May need to add others here as they're
+            # discovered . . .
             if name in ['methods', 'utils']:
                 continue
-            # add padding
+
+            # add padding to version string
             if version:
                 version = " " + version
+
             if name.lower() == 'r':
+                # "r >=2.5" rather than "r-r >=2.5"
                 specific_r_version = True
                 results.append(name.lower() + version)
             else:
                 results.append(prefix + name.lower() + version)
 
+        # Add R itself if no specific version was specified
         if not specific_r_version:
             results.append('r')
         return results
 
     @property
-    def cleaned_package(self):
-        return 'bioconductor-' + self.package.lower()
-
-    @property
     def md5(self):
+        """
+        Calculate the md5 hash of the tarball so it can be filled into the
+        meta.yaml.
+        """
         if self._md5 is None:
             self._md5 = hashlib.md5(
                 open(self.cached_tarball, 'rb').read()).hexdigest()
         return self._md5
 
     @property
-    def summary(self):
-        return str(self.soup.h2.string)
-
-    @property
     def meta_yaml(self):
+        """
+        Build the meta.yaml string based on discovered values.
+
+        Here we use a nested OrderedDict so that all meta.yaml files created by
+        this script have the same consistent format. Otherwise we're the whims
+        of Python dict sorting.
+
+        We use pyaml (rather than yaml) because it has better handling of
+        OrderedDicts.
+        """
         d = OrderedDict((
             (
                 'package', OrderedDict((
-                    ('name', self.cleaned_package),
+                    ('name', 'bioconductor-' + self.package.lower()),
                     ('version', self.version),
                 )),
             ),
@@ -215,8 +270,11 @@ class BioCProjectPage(object):
 
 
 def write_recipe(package, recipe_dir, force=False):
+    """
+    Write the meta.yaml and build.sh files.
+    """
     proj = BioCProjectPage(package)
-    recipe_dir = os.path.join(recipe_dir, proj.sanitized_package)
+    recipe_dir = os.path.join(recipe_dir, 'bioconductor-' + proj.package.lower())
     if os.path.exists(recipe_dir) and not force:
         raise ValueError("{0} already exists, aborting".format(recipe_dir))
     else:

--- a/scripts/bioconductor-scraper.py
+++ b/scripts/bioconductor-scraper.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python
+
+from textwrap import dedent
+import yaml
+import hashlib
+import os
+import re
+import bs4
+from urllib import request
+from urllib import parse
+from collections import OrderedDict
+
+def ordereddict_constructor(loader, node):
+    try:
+        omap = loader.construct_yaml_omap(node)
+        return OrderedDict(*omap)
+    except yaml.constructor.ConstructorError:
+        return loader.construct_yaml_seq(node)
+
+def represent_ordereddict(dumper, data):
+    # From https://bitbucket.org/xi/pyyaml/issues/13/loading-and-then-dumping-an-omap-is-broken
+    values = []
+    node = yaml.SequenceNode(u'tag:yaml.org,2002:seq', values, flow_style=False)
+    if dumper.alias_key is not None:
+        dumper.represented_objects[dumper.alias_key] = node
+    for key, value in data.items():
+        key_item = dumper.represent_data(key)
+        value_item = dumper.represent_data(value)
+        node_item = yaml.MappingNode(u'tag:yaml.org,2002:map', [(key_item, value_item)],
+                                     flow_style=False)
+        values.append(node_item)
+    return node
+
+yaml.add_constructor(u'tag:yaml.org,2002:seq', ordereddict_constructor)
+yaml.add_representer(OrderedDict, represent_ordereddict)
+
+
+class BioCProjectPage(object):
+    def __init__(self, package, base_url='http://bioconductor.org/packages/release/bioc/html'):
+        """
+        Represents a single Bioconductor package page and provides access to scraped data.
+
+        >>> x = BioCProjectPage('DESeq2')
+        >>> x.tarball
+        'http://bioconductor.org/packages/release/bioc/src/contrib/DESeq2_1.8.2.tar.gz'
+        """
+        self.base_url = base_url
+        self.package = package
+        self.url = os.path.join(base_url, package + '.html')
+        self.soup = bs4.BeautifulSoup(
+            request.urlopen(self.url),
+            'html.parser')
+
+        self.details_table = self.soup.find_all(attrs={'class': 'details'})[0]
+        self._md5 = None
+        self.sanitized_package = 'bioconductor-' + package.lower()
+
+    @property
+    def tarball(self):
+        """
+        Return the url to the tarball indicated in the "Package Source" section.
+        """
+        r = re.compile('{0}.*\.tar.gz'.format(self.package))
+        def f(href):
+            return href and r.search(href)
+        results = self.soup.find_all(href=f)
+        assert len(results) == 1, "Found {0} tags with '.tar.gz' in href".format(len(results))
+        s = list(results[0].stripped_strings)
+        assert len(s) == 1
+        return os.path.join(parse.urljoin(self.url, '../src/contrib'), s[0])
+
+    @property
+    def tarball_filename(self):
+        return os.path.basename(self.tarball)
+
+    @property
+    def version(self):
+        return str(self.details_table.findChild(text='Version').findNext().string)
+
+    @property
+    def license(self):
+        return str(self.details_table.findChild(text='License').findNext().string)
+
+    @property
+    def imports(self):
+        return self.details_table.findChild(text='Imports').findNext().findChildren()
+
+
+    @property
+    def dependencies(self):
+        def _versioned_dependencies(children):
+            results = []
+            for c in children:
+                if c.name == 'a':
+                    pkg = c.string
+                else:
+                    continue
+                if c.next_sibling and c.next_sibling.name is None:
+                    version = c.next_sibling.string.replace(' ', '').replace(',', '')
+                    if version:
+                        version = version.replace('(', ' ').replace(')', '')
+                else:
+                    version = ""
+                if c.get('class') == ['cran_package']:
+                    prefix = 'r-'
+                else:
+                    prefix = 'bioconductor-'
+                results.append(prefix + pkg.lower() + version + ' # ' + pkg)
+            return results
+        return list(set(_versioned_dependencies(self.imports) + _versioned_dependencies(self.depends)))
+
+
+    @property
+    def depends(self):
+        return self.details_table.findChild(text='Depends').findNext()
+
+    @property
+    def cleaned_package(self):
+        return 'bioconductor-' + self.package.lower()
+
+    @property
+    def md5(self):
+        if self._md5 is None:
+            self._md5 = hashlib.md5(request.urlopen(self.tarball).read()).hexdigest()
+        return self._md5
+
+    @property
+    def summary(self):
+        return str(self.soup.h2.string)
+
+    @property
+    def meta_yaml(self):
+        d = OrderedDict((
+            (
+                'package', OrderedDict((
+                    ('name', self.cleaned_package),
+                    ('version', self.version),
+                )),
+            ),
+            (
+                'source', OrderedDict((
+                    ('fn', self.tarball_filename),
+                    ('url', self.tarball),
+                    ('md5', self.md5),
+                )),
+            ),
+            (
+                'build', OrderedDict((
+                    ('number', 0),
+                    ('rpaths', ['lib/R/lib/', 'lib/']),
+                )),
+            ),
+            (
+                'requirements', OrderedDict((
+                    ('build', ['r'] + sorted(self.dependencies)),
+                    ('run', ['r'] + sorted(self.dependencies)),
+                )),
+            ),
+            (
+                'test', OrderedDict((
+                    ('commands', """$R -e "library('{package}')""".format(package=self.package)),
+                )),
+            ),
+            (
+                'about', OrderedDict((
+                    ('home', self.url),
+                    ('license', self.license),
+                    ('summary', self.summary),
+                )),
+            ),
+        ))
+        return yaml.dump(d, default_flow_style=False)
+
+
+
+def write_recipe(package, recipe_dir, force=False):
+    proj = BioCProjectPage(package)
+    recipe_dir = os.path.join(recipe_dir, proj.sanitized_package)
+    if os.path.exists(recipe_dir) and not force:
+        raise ValueError("{0} already exists, aborting".format(recipe_dir))
+    else:
+        if not os.path.exists(recipe_dir):
+            print('creating %s' % recipe_dir)
+            os.makedirs(recipe_dir)
+
+    with open(os.path.join(recipe_dir, 'meta.yaml'), 'w') as fout:
+        fout.write(proj.meta_yaml)
+
+    with open(os.path.join(recipe_dir, 'build.sh'), 'w') as fout:
+        fout.write(dedent(
+            """
+            #!/bin/bash
+
+            # R refuses to build packages that mark themselves as Priority: Recommended
+            # mv DESCRIPTION DESCRIPTION.old
+            # grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+            #
+            # $R CMD INSTALL --build .
+            #
+            # # Add more build steps here, if they are necessary.
+            #
+            # # See
+            # # http://docs.continuum.io/conda/build.html
+            # # for a list of environment variables that are set during the build process.
+            # """
+            )
+        )
+
+
+if __name__ == "__main__":
+    import argparse
+    ap = argparse.ArgumentParser()
+    ap.add_argument('package', help='Bioconductor package name')
+    ap.add_argument('--recipe-dir', default='recipes',
+                    help='Recipe will be created in <recipe-dir>/<package>')
+    ap.add_argument('--force', action='store_true', help='Overwrite the contents of an existing recipe')
+    args = ap.parse_args()
+    write_recipe(args.package, args.recipe_dir, args.force)


### PR DESCRIPTION
Writing the bioconductor `meta.yaml` files is getting annoying, so this PR includes a script that scrapes the bioconductor project page for a given package, downloads the tarball, and inspects the DESCRIPTION file to extract metadata and create the `meta.yaml` and `build.sh` files.

This is because I couldn't get the `conda skeleton cran` subcommand to work for Bioconductor.

To have uniformly-formatted YAML files, I'm using `pyaml` which can write a new yaml file that maintains the order of an OrderedDict. So part of the PR also includes the conda recipe for `pyaml`.