### PR TITLE
Update Dockerfile to use latest gcc/libtools

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -2,10 +2,11 @@ FROM centos:centos5
 RUN rpm -Uvh http://dl.fedoraproject.org/pub/epel/5/x86_64/epel-release-5-4.noarch.rpm
 RUN yum install -y wget bzip2 bzip2-devel git gcc gcc-c++ patch zlib-devel make gcc44 gcc44-c++ cmake ncurses-devel
 RUN wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo
-RUN yum install -y devtoolset-2-gcc devtoolset-2-binutils devtoolset-2-gcc-c++ autoconf automake libtool
+RUN wget --no-check-certificate https://copr.fedoraproject.org/coprs/praiskup/autotools/repo/epel-5/praiskup-autotools-epel-5.repo -O /etc/yum.repos.d/autotools.repo
+RUN yum install -y devtoolset-2-gcc devtoolset-2-binutils devtoolset-2-gcc-c++ autotools-latest
 RUN mkdir -p /tmp/conda-build
 RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b -p /anaconda
-ENV PATH=/anaconda/bin:$PATH
+ENV PATH=/opt/rh/devtoolset-2/root/usr/bin:/opt/rh/autotools-latest/root/usr/bin:/anaconda/bin:$PATH
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 RUN mkdir -p /anaconda/conda-bld/linux-64 # workaround for bug in current conda

--- a/scripts/update_packages_docker.sh
+++ b/scripts/update_packages_docker.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 set -eu -o pipefail
 
-# enable gcc-4.8
-export MANPATH=""
-source /opt/rh/devtoolset-2/enable
-cd /tmp/conda-recipes
+# # enable gcc-4.8
+# export MANPATH=""
+# source /opt/rh/devtoolset-2/enable
+# #
+# mkdir -p /tmp/conda-build
+# cd /tmp/conda-build
+# rm -rf /anaconda
+# wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
+# bash Miniconda-latest-Linux-x86_64.sh -b -p /tmp/conda-build/anaconda
+# export PATH=/tmp/conda-build/anaconda/bin:$PATH
+# conda install -y conda conda-build anaconda-client pyyaml toolz jinja2
+cd /bioconda
 anaconda login --hostname bcbio-conda-auto --username `cat anaconda-user.txt` --password `cat anaconda-pass.txt`
-cd /tmp/conda-recipes
-export PATH=/tmp/conda-build/anaconda/bin:$PATH
-/tmp/conda-build/anaconda/bin/python update_packages.py $*
+python scripts/update_packages.py $*


### PR DESCRIPTION
Johannes;
I didn't want to stomp on your current Dockerfile and bioconda/bioconda-builder image so submitting this as a PR for your approval. This gets gcc and other build tools up to date on the image for automated builds, which should help a lot in resolving build issues. Let me know the best way to push this to the automatic builds if you approve.

The current Dockerfile uses the default gcc on centos5, gcc 4.1. This
will fail to build quite a few current tools. This updates the
Dockerfile to put gcc-4.8, from devtoolset-2 in the PATH by default.

It also adds recent libtool versions to get up to date autoconf,
automake and friends, avoiding the issues in #10.

Together, this should create a more pleasant build environment that
will handle most tools.

This also updates custom test scripts to handle changes to python 3.