### PR TITLE
bcftools/samtools/bwa: CentOS 5 compatible builds

### DIFF
--- a/recipes/bcftools/meta.yaml
+++ b/recipes/bcftools/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: bcftools
   version: "1.2"
+build:
+  number: 1
 source:
   fn: bcftools-1.2.tar.bz2
   url: https://github.com/samtools/bcftools/releases/download/1.2/bcftools-1.2.tar.bz2

--- a/recipes/bwa/meta.yaml
+++ b/recipes/bwa/meta.yaml
@@ -5,7 +5,8 @@ build:
   number: 1
 source:
   fn: bwa-0.7.12.tar.bz2
-  url: http://downloads.sourceforge.net/project/bio-bwa/bwa-0.7.12.tar.bz2
+  url: https://github.com/lh3/bwa/archive/0.7.12.tar.gz
+  #url: http://downloads.sourceforge.net/project/bio-bwa/bwa-0.7.12.tar.bz2
 requirements:
   build:
   run:

--- a/recipes/bwa/meta.yaml
+++ b/recipes/bwa/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: bwa
   version: "0.7.12"
+build:
+  number: 1
 source:
   fn: bwa-0.7.12.tar.bz2
   url: http://downloads.sourceforge.net/project/bio-bwa/bwa-0.7.12.tar.bz2

--- a/recipes/samtools/meta.yaml
+++ b/recipes/samtools/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: samtools
   version: "1.2"
+build:
+  number: 1
 source:
   fn: samtools-1.2.tar.bz2
   url: https://github.com/samtools/samtools/releases/download/1.2/samtools-1.2.tar.bz2


### PR DESCRIPTION
Bumps builds for bcftools, samtools and bwa to create packages in
the Linux docker container supporting CentOS.