### PR TITLE
Fix build python requirement in snakemake

### DIFF
--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -10,7 +10,7 @@ build:
     - snakemake-bash-completion = snakemake:bash_completion
 requirements:
   build:
-    - python ==3.4.3
+    - python >=3.4.3
     - setuptools
   run:
     - python >=3.3


### PR DESCRIPTION
So on OSX + py35, the currently uploaded conda package seems to *hard-code* the installation path to python3.4/site-packages, rather than python3.X/site-packages.  See the logs below for evidence.  I can't fully verify whether the problem is part of the recipe or your build process, but I can't see any reason to hard-code the build version.  


```
snakemake -v
Traceback (most recent call last):
  File "~/opt/envs/py35/bin/snakemake", line 4, in <module>
    from snakemake import main
ImportError: No module named 'snakemake'


ls ~/opt/envs/py35/lib/python3.*/site-packages/snake*
~/opt/envs/py35/lib/python3.4/site-packages/snakemake-3.4.2-py3.4.egg-info

~/opt/envs/py35/lib/python3.4/site-packages/snakemake:
__init__.py     dag.py          executors.py    gui.html        io.py           jobscript.sh    output_index.py persistence.py  report.py       scheduler.py    stats.py        version.py
__pycache__     exceptions.py   futures.py      gui.py          jobs.py         logging.py      parser.py       report.css      rules.py        shell.py        utils.py        workflow.py
```