### PR TITLE
Remove rpy2 dependency.

### DIFF
--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -17,7 +17,6 @@ requirements:
     - python >=3.3
     - docutils
     - pyyaml
-    - rpy2
 test:
     imports:
       - snakemake


### PR DESCRIPTION
rpy2 dependency apparently causes a recursion depth error in conda. I have no idea why, but always pulling R only for installing Snakemake is not a good idea anyway.