### PR TITLE
Remove dependency constraint for python version (>=3.3)

### DIFF
--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -11,10 +11,10 @@ build:
     - snakemake-bash-completion = snakemake:bash_completion
 requirements:
   build:
-    - python >=3.3
+    - python
     - setuptools
   run:
-    - python >=3.3
+    - python
     - docutils
     - pyyaml
 test:


### PR DESCRIPTION
because it always leads to creating a 3.5 package that is not marked with a particular Python version.
Instead, we let the 27 build just fail.