### PR TITLE
add MAFFT

### DIFF
--- a/recipes/mafft/build.sh
+++ b/recipes/mafft/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# cd to location of Makefile and source
+cd $SRC_DIR/core
+
+export PRFX=$PREFIX
+make
+make install

--- a/recipes/mafft/meta.yaml
+++ b/recipes/mafft/meta.yaml
@@ -1,0 +1,16 @@
+about:
+    home: 'http://mafft.cbrc.jp/alignment/software/'
+    license: BSD
+    summary: Multiple alignment program for amino acid or nucleotide sequences based on fast Fourier transform
+package: 
+  name: mafft
+  version: '7.221'
+source:
+  fn: mafft-7.221-without-extensions-src.tgz
+  md5: 6b05a64d2ccfce1fd203a6a52776d401
+  url: http://mafft.cbrc.jp/alignment/software/mafft-7.221-without-extensions-src.tgz
+  patches:
+    - osx-makefile.patch
+test:
+    commands:
+        - mafft --version

--- a/recipes/mafft/osx-makefile.patch
+++ b/recipes/mafft/osx-makefile.patch
@@ -1,0 +1,17 @@
+--- core/Makefile	2015-10-19 11:46:17.000000000 -0400
++++ core/osx-makefile	2015-10-19 12:06:49.000000000 -0400
+@@ -1,4 +1,4 @@
+-PREFIX = /usr/local
++PREFIX = $(PRFX)
+ LIBDIR = $(PREFIX)/libexec/mafft
+ BINDIR = $(PREFIX)/bin
+ MANDIR = $(PREFIX)/share/man/man1
+@@ -6,7 +6,7 @@
+ 
+ #MNO_CYGWIN = -mno-cygwin
+ 
+-ENABLE_MULTITHREAD = -Denablemultithread
++#ENABLE_MULTITHREAD = -Denablemultithread
+ # Comment out the above line if your compiler 
+ # does not support TLS (thread-local strage).
+ 


### PR DESCRIPTION
conda recipe for [MAFFT](http://mafft.cbrc.jp/alignment/software/), a multiple alignment program for amino acid or
nucleotide sequences based on fast Fourier transform