### PR TITLE
Add GNU Parallel, avoid conflict from moreutils

### DIFF
--- a/recipes/moreutils/build.sh
+++ b/recipes/moreutils/build.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 set -eu -o pipefail
 
+# Skip man files due to dependencies
 sed -i 's/^MANS=.*/MANS=/' Makefile
 sed -i 's/install $(MANS)/# install $(MANS)/' Makefile
+# avoid installing parallel since it conflicts with GNU parallel
+sed -i 's/parallel//' Makefile
 make PREFIX=$PREFIX
 make install PREFIX=$PREFIX

--- a/recipes/moreutils/meta.yaml
+++ b/recipes/moreutils/meta.yaml
@@ -7,7 +7,7 @@ source:
   url: http://http.debian.net/debian/pool/main/m/moreutils/moreutils_0.57.orig.tar.gz
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/parallel/build.sh
+++ b/recipes/parallel/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix=$PREFIX
+make
+make install

--- a/recipes/parallel/meta.yaml
+++ b/recipes/parallel/meta.yaml
@@ -1,0 +1,26 @@
+# GNU Parallel
+# updated to latest from https://github.com/ostrokach/conda-recipes-extra/tree/master/parallel
+
+package:
+  name: parallel
+  version: 20150922
+
+source:
+  url: http://gnu.mirror.iweb.com/parallel/parallel-20150922.tar.bz2
+  fn: parallel-20150922.tar.bz2
+
+build:
+  number: 0
+
+requirements:
+  build:
+  run:
+
+test:
+  commands:
+    - parallel --version
+
+about:
+  home: http://www.gnu.org/software/parallel/
+  license: GNU
+  summary: GNU parallel is a shell tool for executing jobs in parallel using one or more computers.


### PR DESCRIPTION
Removes `parallel` from moreutils, which conflicts with the more widely
used GNU parallel. Add recipe for GNU parallel.