### PR TITLE
Add knot

### DIFF
--- a/recipes/knot/build.sh
+++ b/recipes/knot/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+mkdir -p $PREFIX/bin
 make
 cp topol $PREFIX/bin/knot
 

--- a/recipes/knot/meta.yaml
+++ b/recipes/knot/meta.yaml
@@ -13,6 +13,7 @@ build:
 test:
   commands:
     - which knot
+    - "knot || [[ $? == 139 ]]"
 
 about:
   home: http://mathbio.nimr.mrc.ac.uk/wiki/Software#KNOT

--- a/recipes/knot/meta.yaml
+++ b/recipes/knot/meta.yaml
@@ -10,15 +10,7 @@ source:
 build:
   number: 1
 
-requirements:
-  build:
-    - system
-  run:
-    - system
-
 test:
-  requires: 
-    - knot
   commands:
     - which knot
 


### PR DESCRIPTION
Added a binary for the program `knot`. It is useful in validating protein homology models, since "bad" models are more likely to be knotted than "good" models.