### PR TITLE
Msms

### DIFF
--- a/recipes/msms/build.sh
+++ b/recipes/msms/build.sh
@@ -7,15 +7,6 @@ mkdir -p "$PREFIX/lib/msms"
 sed -i "s|numfile = \"./atmtypenumbers\"|numfile = \"$PREFIX/lib/msms/atmtypenumbers\"|" pdb_to_xyzr
 sed -i "s|numfile = \"./atmtypenumbers\"|numfile = \"$PREFIX/lib/msms/atmtypenumbers\"|" pdb_to_xyzrn
 
-# Change `nawk` to `awk`, since `nawk` is not installed on some platforms
-sed -i 's|nawk|awk|g' pdb_to_xyzrn
-
-# Patch pdb_to_xyzrn so that it includes the chain in its output
-sed -i 's|resnum=substr($0,23,4);|resnum=substr($0,23,4);\n\tchain=substr($0,21,2);|' pdb_to_xyzrn
-sed -i 's|gsub(" ", "", aname);|gsub(" ", "", aname);\n\tgsub(" ", "", resnum);\n\tgsub(" ", "", chain);|' pdb_to_xyzrn
-sed -i 's|"%f %f %f %f %d %s_%s_%d\\n", x, y, z, |"%f %f %f %f %d %s_%s_%d_%s\\n", x, y, z, |g' pdb_to_xyzrn
-sed -i 's|1, aname, resname, resnum);|1, aname, resname, resnum, chain);|g' pdb_to_xyzrn
-
 # Copy files to the conda bin/ folder
 cp ./pdb_to_xyzr $PREFIX/bin
 cp ./pdb_to_xyzrn $PREFIX/bin

--- a/recipes/msms/build.sh
+++ b/recipes/msms/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+mkdir -p "$PREFIX/bin"
+mkdir -p "$PREFIX/lib/msms"
+
+# Look for `atmtypenumbers` in the library folder instead of the current folder
+sed -i "s|numfile = \"./atmtypenumbers\"|numfile = \"$PREFIX/lib/msms/atmtypenumbers\"|" pdb_to_xyzr
+sed -i "s|numfile = \"./atmtypenumbers\"|numfile = \"$PREFIX/lib/msms/atmtypenumbers\"|" pdb_to_xyzrn
+
+# Change `nawk` to `awk`, since `nawk` is not installed on some platforms
+sed -i 's|nawk|awk|g' pdb_to_xyzrn
+
+# Patch pdb_to_xyzrn so that it includes the chain in its output
+sed -i 's|resnum=substr($0,23,4);|resnum=substr($0,23,4);\n\tchain=substr($0,21,2);|' pdb_to_xyzrn
+sed -i 's|gsub(" ", "", aname);|gsub(" ", "", aname);\n\tgsub(" ", "", resnum);\n\tgsub(" ", "", chain);|' pdb_to_xyzrn
+sed -i 's|"%f %f %f %f %d %s_%s_%d\\n", x, y, z, |"%f %f %f %f %d %s_%s_%d_%s\\n", x, y, z, |g' pdb_to_xyzrn
+sed -i 's|1, aname, resname, resnum);|1, aname, resname, resnum, chain);|g' pdb_to_xyzrn
+
+# Copy files to the conda bin/ folder
+cp ./pdb_to_xyzr $PREFIX/bin
+cp ./pdb_to_xyzrn $PREFIX/bin
+cp ./msms.x86_64Linux2.2.6.1 $PREFIX/bin/msms
+cp ./atmtypenumbers $PREFIX/lib/msms
+
+chmod +x $PREFIX/bin/pdb_to_xyzr
+chmod +x $PREFIX/bin/pdb_to_xyzrn
+

--- a/recipes/msms/meta.yaml
+++ b/recipes/msms/meta.yaml
@@ -16,15 +16,7 @@ build:
     - bin/pdb_to_xyzr
     - bin/pdb_to_xyzrn
 
-requirements:
-  build:
-    - system
-  run:
-    - system
-
 test:
-  requires: 
-    - msms
   commands:
     - msms -h
 

--- a/recipes/msms/meta.yaml
+++ b/recipes/msms/meta.yaml
@@ -1,0 +1,31 @@
+package:
+  name: msms
+  version: "2.6.1"
+
+source:
+  fn: msms_i86_64Linux2_2.6.1.tar.gz
+  url: http://mgltools.scripps.edu/downloads/tars/releases/MSMSRELEASE/REL2.6.1/msms_i86_64Linux2_2.6.1.tar.gz
+  md5: 650d8c6fd49d9ce291f30ed530d5f313
+
+build:
+  number: 1
+  has_prefix_files:
+    - bin/pdb_to_xyzr
+    - bin/pdb_to_xyzrn
+
+requirements:
+  build:
+    - system
+  run:
+    - system
+
+test:
+  requires: 
+    - msms
+  commands:
+    - msms -h
+
+about:
+  home: http://mgltools.scripps.edu/packages/MSMS/
+  license: Free for academic use.
+  summary: MSMS is a program written in the C programming language to compute molecular surfaces. 

--- a/recipes/msms/meta.yaml
+++ b/recipes/msms/meta.yaml
@@ -6,6 +6,9 @@ source:
   fn: msms_i86_64Linux2_2.6.1.tar.gz
   url: http://mgltools.scripps.edu/downloads/tars/releases/MSMSRELEASE/REL2.6.1/msms_i86_64Linux2_2.6.1.tar.gz
   md5: 650d8c6fd49d9ce291f30ed530d5f313
+  patches:
+    - pdb_to_xyzr.patch
+    - pdb_to_xyzrn.patch
 
 build:
   number: 1

--- a/recipes/msms/pdb_to_xyzr.patch
+++ b/recipes/msms/pdb_to_xyzr.patch
@@ -1,0 +1,11 @@
+--- pdb_to_xyzr	2015-10-27 17:18:46.425473839 -0400
++++ pdb_to_xyzr	2015-10-27 17:19:43.017473698 -0400
+@@ -28,7 +28,7 @@
+ 	shift
+ 	fi
+ fi
+-nawk 'BEGIN{
++awk 'BEGIN{
+ 	# read radius table and patterns from supplied file
+ 	npats=0
+ 	numfile = "./atmtypenumbers"

--- a/recipes/msms/pdb_to_xyzrn.patch
+++ b/recipes/msms/pdb_to_xyzrn.patch
@@ -1,0 +1,35 @@
+--- pdb_to_xyzrn	2015-10-27 17:18:52.833473823 -0400
++++ pdb_to_xyzrn	2015-10-27 17:19:29.713473731 -0400
+@@ -28,7 +28,7 @@
+ 	shift
+ 	fi
+ fi
+-nawk 'BEGIN{
++awk 'BEGIN{
+ 	# read radius table and patterns from supplied file
+ 	npats=0
+ 	numfile = "./atmtypenumbers"
+@@ -80,10 +80,13 @@
+ 
+ 
+ 	resnum=substr($0,23,4);
++	chain=substr($0,21,2);
+ 
+ 	# trim any blanks
+ 	gsub(" ", "", resname);
+ 	gsub(" ", "", aname);
++	gsub(" ", "", resnum);
++	gsub(" ", "", chain);
+ 
+ 	for(pat=0;pat<npats;pat++) {
+ 		if( aname ~ atmpat[pat] && resname ~ respat[pat] ) break 
+@@ -96,7 +99,7 @@
+ 		  | "cat 1>&2" # write to stderr
+ 		print x,y,z,0.01
+ 		}
+-	else printf("%f %f %f %f %d %s_%s_%d\n", x, y, z, \
+-	  ('$h_select'== 5 ? united_rad[atmnum[pat]]:explicit_rad[atmnum[pat]]), 1, aname, resname, resnum);
++	else printf("%f %f %f %f %d %s_%s_%d_%s\n", x, y, z, \
++	  ('$h_select'== 5 ? united_rad[atmnum[pat]]:explicit_rad[atmnum[pat]]), 1, aname, resname, resnum, chain);
+ 	next;
+ 	}' $*


### PR DESCRIPTION
Added a binary for the program `msms`. In my experience, msms is the best program for calculating solvent-exposed surface area (SASA) for proteins. The most common alternative is [NACCESS](http://www.bioinf.manchester.ac.uk/naccess/), but it carries a more restrictive license and crashes for large PDB files. The patch files change gawk to awk, because gawk is not installed on some of the clusters that I use, and adds the chain of the residue in the output, which makes it easier to link SASA scores back to the original PDB structure.