### PR TITLE
specify only py27 from within crossmap recipe

### DIFF
--- a/recipes/crossmap/meta.yaml
+++ b/recipes/crossmap/meta.yaml
@@ -5,6 +5,12 @@ source:
   url: http://sourceforge.net/projects/crossmap/files/CrossMap-0.2.1.tar.gz
   fn: CrossMap-0.2.1.tar.gz
   md5: 210a50fe7b29f18a119b00c4f033e9b3
+build:
+    number: 1
+
+    # CrossMap is very particular about Python version.
+    skip: True # [not py27]
+
 requirements:
   build:
     - python


### PR DESCRIPTION
this passed the PR tests before because py27 built but py35 didn't. This causes
the py35 build to be skipped, hopefully making things more robust in the future.