### PR TITLE
mosaik now dynamically linked on linux

### DIFF
--- a/recipes/mosaik/linux.inc.patch
+++ b/recipes/mosaik/linux.inc.patch
@@ -1,0 +1,6 @@
+--- src/includes/linux.inc	2015-10-29 10:51:10.000000000 -0400
++++ src/includes/linux-static.inc	2015-10-29 10:52:09.000000000 -0400
+@@ -1,2 +1,2 @@
+ # define our processor specific flags
+-export PLATFORM_FLAGS = -D_FILE_OFFSET_BITS=64 -static
++export PLATFORM_FLAGS = -D_FILE_OFFSET_BITS=64

--- a/recipes/mosaik/meta.yaml
+++ b/recipes/mosaik/meta.yaml
@@ -11,6 +11,9 @@ source:
   url: https://github.com/wanpinglee/MOSAIK/archive/e04c806bb1410cf1dbd1534991c46d696aec6723.zip # pinned to a commit hash since the repo is not using tags
   patches:
     - osx-makefile.patch # [osx]
+    - linux.inc.patch # [linux]
 test:
     commands:
         - "cd $SRC_DIR/demo && ls ../bin/ && bash Build.sh &> /dev/null && bash Align.sh &> /dev/null"
+build:
+  number: 1


### PR DESCRIPTION
mosaik is now dynamically linked on linux. previous compile options
included “-static”. This was removed.