### PR TITLE
STAR: update to 2.5.0a.

### DIFF
--- a/recipes/star/meta.yaml
+++ b/recipes/star/meta.yaml
@@ -1,10 +1,13 @@
 package:
   name: star
-  version: "2.4.2a"
+  version: "2.5.0a"
 source:
-  fn: STAR_2.4.2a.tar.gz
-  url: https://github.com/alexdobin/STAR/archive/STAR_2.4.2a.tar.gz
+  fn: STAR_2.5.0a.tar.gz
+  url: https://github.com/alexdobin/STAR/archive/STAR_2.5.0a.tar.gz
 about:
   home: https://github.com/alexdobin/STAR
   license: GPLv3
   summary: An RNA-seq read aligner.
+test:
+  commands:
+    - STAR --version


### PR DESCRIPTION
2.5.0a fixes a showstopper bug in genome generation and includes some features for controlling how chimeric junctions are called.