### PR TITLE
Lumpy SV calling ecosystem + CrossMap update

### DIFF
--- a/recipes/crossmap/build.sh
+++ b/recipes/crossmap/build.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
-
+rm -rf lib/bx
+rm -rf lib/bx_extras
+rm -rf lib/psyco_full.py
+rm -rf lib/pysam
+rm -rf lib/samtools
+rm -rf lib/tabix
+rm -rf lib/src
 $PYTHON setup.py install

--- a/recipes/crossmap/meta.yaml
+++ b/recipes/crossmap/meta.yaml
@@ -1,12 +1,14 @@
 package:
   name: crossmap
-  version: "0.2.1"
+  version: "0.2.2"
 source:
-  url: http://sourceforge.net/projects/crossmap/files/CrossMap-0.2.1.tar.gz
-  fn: CrossMap-0.2.1.tar.gz
-  md5: 210a50fe7b29f18a119b00c4f033e9b3
+  url: http://sourceforge.net/projects/crossmap/files/CrossMap-0.2.2.tar.gz
+  fn: CrossMap-0.2.2.tar.gz
+  patches:
+    - setup_remove_deps.diff
+
 build:
-    number: 1
+    number: 0
 
     # CrossMap is very particular about Python version.
     skip: True # [not py27]
@@ -18,16 +20,21 @@ requirements:
     - numpy
     - setuptools
     - nose
+    - pysam
+    - bx-python
   run:
     - python
     - cython
     - numpy
     - setuptools
     - nose
+    - pysam
+    - bx-python
 
 test:
   commands:
-    - "CrossMap.py"
+    - CrossMap.py bed
+    - CrossMap.py vcf
 
 about:
   home: http://crossmap.sourceforge.net

--- a/recipes/crossmap/setup_remove_deps.diff
+++ b/recipes/crossmap/setup_remove_deps.diff
@@ -1,0 +1,11 @@
+--- setup.py.orig	2015-05-15 18:14:37.000000000 -0400
++++ setup.py	2015-07-16 10:53:53.813643137 -0400
+@@ -65,7 +65,7 @@
+             package_dir = { '': 'lib' },
+             package_data = { '': ['*.ps'] },
+             scripts = glob.glob( "bin/*.py"),
+-            ext_modules = get_extension_modules(),
++            ext_modules = [],
+             test_suite = 'nose.collector',
+             setup_requires = ['nose>=0.10.4','cython>=0.12'],
+             author = "Liguo Wang",

--- a/recipes/lumpy-sv/build.sh
+++ b/recipes/lumpy-sv/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -eu -o pipefail
+
+outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+mkdir -p $outdir
+mkdir -p $outdir/scripts
+mkdir -p $outdir/scripts/bamkit
+mkdir -p $PREFIX/bin
+
+make
+cp bin/lumpy $PREFIX/bin
+cp scripts/lumpyexpress $PREFIX/bin
+
+cp scripts/*.py $outdir/scripts
+cp scripts/*.sh $outdir/scripts
+cp scripts/*.pl $outdir/scripts
+cp scripts/extractSplitReads* $outdir/scripts
+cp scripts/vcf* $outdir/scripts
+cp scripts/bamkit/* $outdir/scripts/bamkit
+
+cp $RECIPE_DIR/lumpyexpress.config $outdir
+ln -s $outdir/lumpyexpress.config $PREFIX/bin

--- a/recipes/lumpy-sv/lumpyexpress.config
+++ b/recipes/lumpy-sv/lumpyexpress.config
@@ -1,0 +1,29 @@
+#!/bin/bash -e
+
+# Find original directory of file, resovling symlinks
+# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in/246128#246128
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+# general
+LUMPY_HOME=$DIR
+
+LUMPY=`which lumpy || true`
+SAMBLASTER=`which samblaster || true`
+# either sambamba or samtools is required
+SAMBAMBA=`which sambamba || true`
+SAMTOOLS=`which samtools || true`
+
+# python 2.7 or newer, must have pysam, numpy installed
+PYTHON=`which python || true`
+
+# python scripts
+PAIREND_DISTRO=$LUMPY_HOME/scripts/pairend_distro.py
+BAMGROUPREADS=$LUMPY_HOME/scripts/bamkit/bamgroupreads.py
+BAMFILTERRG=$LUMPY_HOME/scripts/bamkit/bamfilterrg.py
+BAMLIBS=$LUMPY_HOME/scripts/bamkit/bamlibs.py

--- a/recipes/lumpy-sv/meta.yaml
+++ b/recipes/lumpy-sv/meta.yaml
@@ -1,0 +1,22 @@
+package:
+  name: lumpy-sv
+  version: 0.2.11
+source:
+  fn: lumpy-sv-0.2.11.tar.gz
+  url: https://github.com/arq5x/lumpy-sv/releases/download/0.2.11/lumpy-sv-0.2.11.tar.gz
+build:
+  number: 0
+  skip: True # [not py27]
+requirements:
+  build:
+  run:
+    - python
+    - samtools
+test:
+    commands:
+      - 'lumpy 2>&1 | grep -q structural'
+      - 'lumpyexpress 2>&1 | grep -q lumpyexpress'
+about:
+    home: https://github.com/arq5x/lumpy-sv
+    license: MIT
+    summary: a general probabilistic framework for structural variant discovery

--- a/recipes/samblaster/build.sh
+++ b/recipes/samblaster/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+BIN=$PREFIX/bin
+mkdir -p $BIN
+make
+cp samblaster $BIN

--- a/recipes/samblaster/meta.yaml
+++ b/recipes/samblaster/meta.yaml
@@ -1,0 +1,22 @@
+# Started based on: https://anaconda.org/Judowill/samblaster
+
+package:
+  name: samblaster
+  version: '0.1.22'
+source:
+  fn: samblaster-v.0.1.22.tar.gz
+  url: https://github.com/GregoryFaust/samblaster/releases/download/v.0.1.22/samblaster-v.0.1.22.tar.gz
+
+requirements:
+  build:
+  run:
+
+test:
+    commands:
+        - samblaster -h
+
+about:
+  home: https://github.com/GregoryFaust/samblaster
+  license: MIT
+  summary: A tool to mark duplicates and extract discordant and split reads from sam files.
+

--- a/recipes/svtyper/build.sh
+++ b/recipes/svtyper/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cp svtyper $PREFIX/bin

--- a/recipes/svtyper/meta.yaml
+++ b/recipes/svtyper/meta.yaml
@@ -1,0 +1,34 @@
+package:
+  name: svtyper
+  version: 0.0.2
+
+source:
+  fn: svtyper-f1e2f59.tar.gz
+  url: https://github.com/hall-lab/svtyper/archive/f1e2f59.tar.gz
+  #fn: svtyper-0.0.2.tar.gz
+  #url: https://github.com/hall-lab/svtyper/archive/v0.0.2.tar.gz
+
+build:
+  number: 3
+  skip: True # [not py27]
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pysam
+
+  run:
+    - python
+    - setuptools
+    - pysam
+
+test:
+  commands:
+    - svtyper -h
+
+about:
+  home: https://github.com/hall-lab/svtyper
+  license: MIT
+  summary: Bayesian genotyper for structural variants
+


### PR DESCRIPTION
- CrossMap -- move to latest version and avoid installing the pysam and
  bx-python that are internally bundled with CrossMap. These cause
  issues as they can conflict with external versions, especially in
  shared libraries. Now we handle these as dependencies, which are
  already in bioconda.
- lumpy-sv -- add recipe, migrating from homebrew
- samblaster -- add recipe, migrating from homebrew
- svtyper -- add recipe, migrating from bcbio-conda