### PR TITLE
Add GATK framework (#200) + bump snpEff build

### DIFF
--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -44,3 +44,5 @@ fastqc
 mageck-vispr
 cnvkit
 sambamba
+gatk-framework
+snpeff

--- a/recipes/gatk-framework/build.sh
+++ b/recipes/gatk-framework/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+mkdir -p $outdir
+mkdir -p $PREFIX/bin
+cp -R ./* $outdir/
+cp $RECIPE_DIR/gatk-framework $outdir/
+chmod +x $outdir/gatk-framework
+
+ln -s $outdir/gatk-framework $PREFIX/bin

--- a/recipes/gatk-framework/gatk-framework
+++ b/recipes/gatk-framework/gatk-framework
@@ -1,0 +1,61 @@
+#!/bin/bash
+# GATK framework executable shell script
+# Wraps MIT licensed GATK code
+# https://github.com/chapmanb/gatk
+
+set -o pipefail
+export LC_ALL=en_US.UTF-8
+
+# Find original directory of bash script, resovling symlinks
+# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in/246128#246128
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+JAR_DIR=$DIR
+
+java=java
+if [ -e "$JAVA_HOME/bin/java" ]
+then
+java="$JAVA_HOME/bin/java"
+fi
+
+# extract memory and system property Java arguments from the list of provided arguments
+# http://java.dzone.com/articles/better-java-shell-script
+default_jvm_mem_opts="-Xms512m -Xmx1g"
+jvm_mem_opts=""
+jvm_prop_opts=""
+pass_args=""
+for arg in "$@"; do
+    case $arg in
+        '-D'*)
+            jvm_prop_opts="$jvm_prop_opts $arg"
+            ;;
+        '-XX'*)
+            jvm_prop_opts="$jvm_prop_opts $arg"
+            ;;
+         '-Xm'*)
+            jvm_mem_opts="$jvm_mem_opts $arg"
+            ;;
+         *)
+            pass_args="$pass_args $arg"
+            ;;
+    esac
+done
+
+if [ "$jvm_mem_opts" == "" ]; then
+    jvm_mem_opts="$default_jvm_mem_opts"
+fi
+
+pass_arr=($pass_args)
+if [[ ${pass_arr[0]} == org* ]]
+then
+    eval "$java" $jvm_mem_opts $jvm_prop_opts -cp "$JAR_DIR/gatk-framework.jar" $pass_args
+else
+    eval "$java" $jvm_mem_opts $jvm_prop_opts -jar "$JAR_DIR/gatk-framework.jar" $pass_args
+fi
+exit

--- a/recipes/gatk-framework/meta.yaml
+++ b/recipes/gatk-framework/meta.yaml
@@ -1,0 +1,20 @@
+about:
+  home: https://github.com/chapmanb/gatk
+  license: MIT
+  summary: The core MIT-licensed Genome Analysis Toolkit (GATK) framework, free for all uses
+package:
+  name: gatk-framework
+  version: '3.4.46'
+build:
+  number: 0
+source:
+  fn: gatk-framework-3.4-46.tar.gz
+  url: https://github.com/chapmanb/gatk/releases/download/v3.4-46-framework/gatk-framework-3.4-46.tar.gz
+requirements:
+  build:
+  run:
+test:
+    commands:
+      - gatk-framework --version
+    requires:
+      - java-jdk

--- a/recipes/snpeff/meta.yaml
+++ b/recipes/snpeff/meta.yaml
@@ -1,10 +1,12 @@
 about:
-    home: 'http://snpeff.sourceforge.net/'
-    license: "LGPLv3"
-    summary: "Genetic variant annotation and effect prediction toolbox"
+  home: 'http://snpeff.sourceforge.net/'
+  license: "LGPLv3"
+  summary: "Genetic variant annotation and effect prediction toolbox"
 package: 
   name: snpeff
   version: '4.1l'
+build:
+  number: 1
 source:
   fn: snpEff_v4_1l_core.zip
   md5: 43dd4b41f3223bbb4cc094ec5c5e2aac


### PR DESCRIPTION
- Add in GATK framework -- the MIT licensed part of the GATK code-base,
  runnable with `gatk-framework`
- The current snpEff package (build 0) does not have updates with
  wrapper script. Bump build number to recreate.