### PR TITLE
Patch cuffmerge for python3

### DIFF
--- a/recipes/cufflinks/cuffmerge.python3.patch
+++ b/recipes/cufflinks/cuffmerge.python3.patch
@@ -1,0 +1,29 @@
+--- cuffmerge	2015-11-13 17:52:47.051643323 +0100
++++ cuffmerge-fixed	2015-11-13 17:55:39.733838706 +0100
+@@ -158,7 +158,7 @@
+         pass
+     else:
+         os.mkdir(tmp_root)
+-    return tmp_root + prefix + os.tmpnam().split('/')[-1]
++    return tempfile.NamedTemporaryFile(dir=tmp_root, prefix=prefix).name
+ 
+ def cufflinks(out_dir,
+               sam_file,
+@@ -485,7 +485,7 @@
+ def header_for_chrom_info(chrom_info):
+     header_strs = ["""@HD\tVN:1.0\tSO:coordinate"""]
+     chrom_list = [(chrom, limits) for chrom, limits in chrom_info.iteritems()]
+-    chrom_list.sort(lambda x,y: cmp(x[0],y[0]))
++    chrom_list.sort(key=lambda x: x[0])
+     #print chrom_list
+     for chrom, limits in chrom_list:
+         line = "@SQ\tSN:%s\tLN:\t%d" % (chrom, limits[1])
+@@ -523,7 +523,7 @@
+         start_time = datetime.now()
+         prepare_output_dir()
+ 
+-        run_log = open(logging_dir + "run.log", "w", 0)
++        run_log = open(logging_dir + "run.log", "w")
+         run_cmd = " ".join(argv)
+         print >> run_log, run_cmd
+ 

--- a/recipes/cufflinks/meta.yaml
+++ b/recipes/cufflinks/meta.yaml
@@ -16,3 +16,5 @@ test:
 source:
   fn: cufflinks-2.2.1.Linux_x86_64.tar.gz
   url: http://cole-trapnell-lab.github.io/cufflinks/assets/downloads/cufflinks-2.2.1.Linux_x86_64.tar.gz
+  patches:
+        - cuffmerge.python3.patch # [py3k]


### PR DESCRIPTION
Cuffmerge uses some methods that are not available on python3. This commit patches on-the-fly the script replacing them with the corresponding python3 constructs.