### PR TITLE
bedtools 2.25.0

### DIFF
--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -48,3 +48,4 @@ gatk-framework
 snpeff
 pythonpy
 metasv
+bedtools

--- a/recipes/bedtools/meta.yaml
+++ b/recipes/bedtools/meta.yaml
@@ -1,13 +1,18 @@
 package:
   name: bedtools
-  version: "2.24.0"
+  version: "2.25.0"
 source:
-  fn: bedtools-2.24.0.tar.gz
-  url: https://github.com/arq5x/bedtools2/releases/download/v2.24.0/bedtools-2.24.0.tar.gz
-  sha256: ea73b8620468c5a15d4ed96dc98c83e5564880bb9651cd75f1dcc96694be60e4
+  fn: bedtools-2.25.0.tar.gz
+  url: https://github.com/arq5x/bedtools2/releases/download/v2.25.0/bedtools-2.25.0.tar.gz
+  sha256: d737ca42e7df76c5455d3e6e0562cdcb62336830eaad290fd4133a328a1ddacc
+build:
+    number: 1
 requirements:
   build:
   run:
+test:
+  commands:
+    - bedtools
 about:
   home: http://bedtools.readthedocs.org/
   license: GPL v2


### PR DESCRIPTION
The existing bedtools conda package pre-dates the CentOS build
environment, so this makes bedtools more portable. It's also built for
OSX.