### PR TITLE
Add lumpy-sv to OSX whitelist

### DIFF
--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -87,3 +87,4 @@ vardict
 vardict-java
 vcflib
 freebayes
+lumpy-sv


### PR DESCRIPTION
Recipe seems to build and install the executables OK.  Not sure if there are eventual downstream issues, but I suppose we can remove later if so desired.